### PR TITLE
feat: scaffold event-driven bot services

### DIFF
--- a/emotion_diary/__init__.py
+++ b/emotion_diary/__init__.py
@@ -1,0 +1,9 @@
+"""Top-level package for the Emotion Diary bot."""
+
+from __future__ import annotations
+
+__all__ = [
+    "__version__",
+]
+
+__version__ = "0.1.0"

--- a/emotion_diary/agents/__init__.py
+++ b/emotion_diary/agents/__init__.py
@@ -1,0 +1,21 @@
+"""Event-driven agents used by the Emotion Diary worker."""
+
+from __future__ import annotations
+
+from .checkin_writer import CheckinWriter
+from .dedup import Dedup
+from .delete import Delete
+from .export import Export
+from .notifier import Notifier
+from .pet_render import PetRender
+from .router import Router
+
+__all__ = [
+    "Router",
+    "Dedup",
+    "CheckinWriter",
+    "PetRender",
+    "Notifier",
+    "Export",
+    "Delete",
+]

--- a/emotion_diary/agents/base.py
+++ b/emotion_diary/agents/base.py
@@ -1,0 +1,21 @@
+"""Common base utilities for agents."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Protocol
+
+from emotion_diary.event_bus import EventBus
+
+
+class SupportsSubscribe(Protocol):
+    def subscribe(self, event_name: str | tuple[str, ...], handler):
+        ...
+
+
+@dataclass(slots=True)
+class Agent:
+    bus: EventBus
+
+    def register(self) -> None:  # pragma: no cover - to be implemented in subclasses
+        raise NotImplementedError

--- a/emotion_diary/agents/checkin_writer.py
+++ b/emotion_diary/agents/checkin_writer.py
@@ -1,0 +1,48 @@
+"""Agent responsible for persisting mood entries."""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from datetime import datetime, timezone
+
+from emotion_diary.event_bus import Event, EventBus
+from emotion_diary.storage import Storage
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass(slots=True)
+class CheckinWriter:
+    bus: EventBus
+    storage: Storage
+
+    def __post_init__(self) -> None:
+        self.bus.subscribe("checkin.save", self.handle)
+
+    async def handle(self, event: Event) -> None:
+        payload = event.payload
+        pid = payload.get("pid")
+        chat_id = payload.get("chat_id")
+        mood = payload.get("mood")
+        ts = payload.get("ts")
+        if pid is None or chat_id is None:
+            logger.debug("Missing pid/chat_id in payload %s", payload)
+            return
+        if mood not in {-1, 0, 1}:
+            logger.debug("Invalid mood %s", mood)
+            return
+        if isinstance(ts, str):
+            ts = datetime.fromisoformat(ts)
+        if not isinstance(ts, datetime):
+            ts = datetime.now(timezone.utc)
+        note = payload.get("note")
+        entry = self.storage.save_entry(pid=pid, ts=ts, mood=mood, note=note)
+        await self.bus.publish(
+            "checkin.saved",
+            {
+                "pid": pid,
+                "chat_id": chat_id,
+                "entry": entry.to_dict(),
+            },
+        )

--- a/emotion_diary/agents/dedup.py
+++ b/emotion_diary/agents/dedup.py
@@ -1,0 +1,60 @@
+"""Deduplication agent filters repeated Telegram updates."""
+
+from __future__ import annotations
+
+import asyncio
+from collections import deque
+from dataclasses import dataclass, field
+from datetime import datetime, timedelta, timezone
+from typing import Deque, Dict, Tuple
+
+from emotion_diary.event_bus import Event, EventBus
+
+
+@dataclass(slots=True)
+class Dedup:
+    bus: EventBus
+    window: timedelta = timedelta(minutes=10)
+    _seen: Dict[int, datetime] = field(init=False, default_factory=dict)
+    _order: Deque[Tuple[int, datetime]] = field(init=False, default_factory=deque)
+
+    def __post_init__(self) -> None:
+        self.bus.subscribe("tg.update", self.handle_update)
+
+    def _prune(self, now: datetime) -> None:
+        while self._order and now - self._order[0][1] > self.window:
+            update_id, _ = self._order.popleft()
+            self._seen.pop(update_id, None)
+
+    async def handle_update(self, event: Event) -> None:
+        if event.metadata.get("dedup_passed"):
+            return
+        update_id = event.payload.get("update_id")
+        if update_id is None:
+            await self.bus.publish(
+                event.name,
+                payload=event.payload,
+                metadata={**event.metadata, "dedup_passed": True},
+            )
+            return
+        timestamp = event.payload.get("ts")
+        if not isinstance(timestamp, datetime):
+            timestamp = datetime.now(timezone.utc)
+        existing = self._seen.get(update_id)
+        if existing and timestamp - existing <= self.window:
+            return
+        self._seen[update_id] = timestamp
+        self._order.append((update_id, timestamp))
+        self._prune(timestamp)
+        await self.bus.publish(
+            event.name,
+            payload=event.payload,
+            metadata={**event.metadata, "dedup_passed": True},
+        )
+
+    async def flush(self) -> None:
+        """Flush the cache, useful for graceful shutdowns/tests."""
+
+        await asyncio.sleep(0)
+        self._seen.clear()
+        self._order.clear()

--- a/emotion_diary/agents/delete.py
+++ b/emotion_diary/agents/delete.py
@@ -1,0 +1,36 @@
+"""Agent that deletes user data on request."""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+
+from emotion_diary.event_bus import Event, EventBus
+from emotion_diary.storage import Storage
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass(slots=True)
+class Delete:
+    bus: EventBus
+    storage: Storage
+
+    def __post_init__(self) -> None:
+        self.bus.subscribe("delete.request", self.handle)
+
+    async def handle(self, event: Event) -> None:
+        payload = event.payload
+        pid = payload.get("pid")
+        chat_id = payload.get("chat_id")
+        if pid is None or chat_id is None:
+            logger.debug("Delete request missing pid/chat_id: %s", payload)
+            return
+        self.storage.delete_user(pid)
+        await self.bus.publish(
+            "delete.done",
+            {
+                "pid": pid,
+                "chat_id": chat_id,
+            },
+        )

--- a/emotion_diary/agents/export.py
+++ b/emotion_diary/agents/export.py
@@ -1,0 +1,54 @@
+"""Agent responsible for CSV exports."""
+
+from __future__ import annotations
+
+import csv
+import logging
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Iterable
+
+from emotion_diary.event_bus import Event, EventBus
+from emotion_diary.storage import Entry, Storage
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass(slots=True)
+class Export:
+    bus: EventBus
+    storage: Storage
+    export_dir: Path
+
+    def __post_init__(self) -> None:
+        self.export_dir.mkdir(parents=True, exist_ok=True)
+        self.bus.subscribe("export.request", self.handle)
+
+    async def handle(self, event: Event) -> None:
+        payload = event.payload
+        pid = payload.get("pid")
+        chat_id = payload.get("chat_id")
+        if pid is None or chat_id is None:
+            logger.debug("Export request missing pid/chat_id: %s", payload)
+            return
+        entries = self.storage.list_entries(pid)
+        file_path = self._write_csv(pid, entries)
+        await self.bus.publish(
+            "export.ready",
+            {
+                "pid": pid,
+                "chat_id": chat_id,
+                "file_path": str(file_path),
+            },
+        )
+
+    def _write_csv(self, pid: str, entries: Iterable[Entry]) -> Path:
+        timestamp = datetime.now(timezone.utc).strftime("%Y%m%d%H%M%S")
+        file_path = self.export_dir / f"{pid}-{timestamp}.csv"
+        with file_path.open("w", newline="", encoding="utf-8") as csvfile:
+            writer = csv.writer(csvfile)
+            writer.writerow(["ts", "mood", "note"])
+            for entry in entries:
+                writer.writerow([entry.ts.isoformat(), entry.mood, entry.note or ""])
+        return file_path

--- a/emotion_diary/agents/notifier.py
+++ b/emotion_diary/agents/notifier.py
@@ -1,0 +1,56 @@
+"""Notifier agent prepares responses for Telegram delivery."""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from datetime import datetime, timezone
+
+from emotion_diary.event_bus import Event, EventBus
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass(slots=True)
+class Notifier:
+    bus: EventBus
+
+    def __post_init__(self) -> None:
+        self.bus.subscribe(
+            ("checkin.saved", "pet.rendered", "ping.request", "export.ready", "delete.done"),
+            self.handle,
+        )
+
+    async def handle(self, event: Event) -> None:
+        payload = event.payload
+        chat_id = payload.get("chat_id")
+        if chat_id is None:
+            logger.debug("Notifier received payload without chat_id: %s", payload)
+            return
+        message = self._build_message(event.name, payload)
+        if message is None:
+            return
+        response = {
+            "chat_id": chat_id,
+            "text": message,
+            "created_at": datetime.now(timezone.utc).isoformat(),
+        }
+        if event.name == "pet.rendered":
+            response["sprite"] = payload.get("sprite")
+        await self.bus.publish("tg.response", response)
+
+    def _build_message(self, event_name: str, payload: dict) -> str | None:
+        if event_name == "checkin.saved":
+            mood = payload.get("entry", {}).get("mood")
+            return f"Записал настроение: {mood}. Спасибо, что поделились!"
+        if event_name == "pet.rendered":
+            sprite = payload.get("sprite")
+            return f"Ваш питомец готов: {sprite}"
+        if event_name == "ping.request":
+            return "Пора рассказать о настроении. Как прошёл день?"
+        if event_name == "export.ready":
+            link = payload.get("file_path")
+            return f"Готов экспорт данных: {link}"
+        if event_name == "delete.done":
+            return "Все данные удалены. Надеемся увидеть вас снова!"
+        return None

--- a/emotion_diary/agents/pet_render.py
+++ b/emotion_diary/agents/pet_render.py
@@ -1,0 +1,48 @@
+"""Agent that picks a virtual pet sprite for the notification."""
+
+from __future__ import annotations
+
+import random
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+
+from emotion_diary.event_bus import Event, EventBus
+
+SPRITES = {
+    -1: ["sprite_sad_1.png", "sprite_sad_2.png"],
+    0: ["sprite_neutral_1.png", "sprite_neutral_2.png"],
+    1: ["sprite_happy_1.png", "sprite_happy_2.png"],
+}
+
+
+@dataclass(slots=True)
+class PetRender:
+    bus: EventBus
+    assets_dir: Path | None = None
+
+    def __post_init__(self) -> None:
+        self.bus.subscribe(("checkin.saved", "ping.request"), self.handle)
+
+    async def handle(self, event: Event) -> None:
+        payload = event.payload
+        pid = payload.get("pid")
+        chat_id = payload.get("chat_id")
+        if pid is None or chat_id is None:
+            return
+        mood = payload.get("entry", {}).get("mood") if "entry" in payload else payload.get("mood", 0)
+        sprite = self._choose_sprite(int(mood or 0))
+        meta = {
+            "pid": pid,
+            "chat_id": chat_id,
+            "sprite": sprite,
+            "rendered_at": datetime.now(timezone.utc).isoformat(),
+        }
+        await self.bus.publish("pet.rendered", meta)
+
+    def _choose_sprite(self, mood: int) -> str:
+        options = SPRITES.get(mood, SPRITES[0])
+        sprite = random.choice(options)
+        if self.assets_dir:
+            return str((self.assets_dir / sprite).resolve())
+        return sprite

--- a/emotion_diary/agents/router.py
+++ b/emotion_diary/agents/router.py
@@ -1,0 +1,117 @@
+"""Router agent converts Telegram updates into domain events."""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from typing import Optional
+
+from emotion_diary.event_bus import Event, EventBus
+from emotion_diary.storage import Storage
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass(slots=True)
+class Router:
+    bus: EventBus
+    storage: Storage
+
+    def __post_init__(self) -> None:
+        self.bus.subscribe("tg.update", self.handle_update)
+
+    async def handle_update(self, event: Event) -> None:
+        if not event.metadata.get("dedup_passed"):
+            return
+        payload = event.payload
+        chat_id = payload.get("chat_id")
+        if chat_id is None:
+            logger.debug("tg.update without chat_id: %s", payload)
+            return
+        ident = self.storage.get_or_create_ident(chat_id)
+        command = self._resolve_command(payload)
+        if command == "export":
+            await self.bus.publish(
+                "export.request",
+                {"pid": ident.pid, "chat_id": chat_id},
+            )
+        elif command == "delete":
+            await self.bus.publish(
+                "delete.request",
+                {"pid": ident.pid, "chat_id": chat_id},
+            )
+        elif command == "checkin":
+            mood = self._resolve_mood(payload)
+            if mood is None:
+                logger.debug("Cannot resolve mood from payload %s", payload)
+                return
+            ts = payload.get("ts")
+            if isinstance(ts, str):
+                ts = datetime.fromisoformat(ts)
+            if not isinstance(ts, datetime):
+                ts = datetime.now(timezone.utc)
+            note = payload.get("note") or payload.get("text")
+            await self.bus.publish(
+                "checkin.save",
+                {
+                    "pid": ident.pid,
+                    "chat_id": chat_id,
+                    "mood": mood,
+                    "ts": ts,
+                    "note": note,
+                },
+            )
+        else:
+            logger.debug("Unhandled command %s", command)
+
+    def _resolve_command(self, payload: dict) -> str | None:
+        data = payload.get("callback_data") or payload.get("text") or ""
+        data = data.strip().lower()
+        if data.startswith("/export"):
+            return "export"
+        if data.startswith("/delete"):
+            return "delete"
+        if data.startswith("/start"):
+            return "checkin"
+        if data.startswith("/checkin"):
+            return "checkin"
+        if any(token in data for token in {"mood", "feeling", "эмоция"}):
+            return "checkin"
+        if payload.get("mood") is not None:
+            return "checkin"
+        return None
+
+    def _resolve_mood(self, payload: dict) -> Optional[int]:
+        if payload.get("mood") is not None:
+            try:
+                mood = int(payload["mood"])
+            except (TypeError, ValueError):
+                mood = None
+        else:
+            text = (payload.get("text") or "").lower()
+            mapping = {
+                "bad": -1,
+                "meh": 0,
+                "ok": 0,
+                "good": 1,
+                "great": 1,
+                "terrible": -1,
+            }
+            if text.startswith("/checkin"):
+                parts = text.split()
+                mood = None
+                if len(parts) > 1:
+                    mood = mapping.get(parts[1])
+                    if mood is None:
+                        try:
+                            mood = int(parts[1])
+                        except ValueError:
+                            mood = None
+            else:
+                mood = mapping.get(text.strip())
+        if mood is None:
+            return None
+        if mood not in {-1, 0, 1}:
+            return None
+        return mood

--- a/emotion_diary/bot/__init__.py
+++ b/emotion_diary/bot/__init__.py
@@ -1,0 +1,3 @@
+"""Command line entry point for running Emotion Diary services."""
+
+__all__ = []

--- a/emotion_diary/bot/__main__.py
+++ b/emotion_diary/bot/__main__.py
@@ -1,0 +1,133 @@
+"""Command line entry-point for Emotion Diary bot services."""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import logging
+import os
+from pathlib import Path
+
+from emotion_diary import __version__
+from emotion_diary.agents import (
+    CheckinWriter,
+    Dedup,
+    Delete,
+    Export,
+    Notifier,
+    PetRender,
+    Router,
+)
+from emotion_diary.event_bus import EventBus
+from emotion_diary.storage import PostgresAdapter, SQLiteAdapter, Storage
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_SQLITE_PATH = "emotion_diary.db"
+DEFAULT_EXPORT_DIR = Path(os.getenv("EMOTION_DIARY_EXPORT_DIR", "./exports"))
+
+
+class ResponseLogger:
+    """Subscribe to ``tg.response`` and log outgoing messages."""
+
+    def __init__(self, bus: EventBus) -> None:
+        self.bus = bus
+        self.bus.subscribe("tg.response", self.handle)
+
+    async def handle(self, event):  # pragma: no cover - logging only
+        payload = event.payload
+        logger.info("TG response for %s: %s", payload.get("chat_id"), payload.get("text"))
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Emotion Diary bot entry-point")
+    parser.add_argument("--mode", choices=["polling", "webhook", "scheduler"], required=True)
+    parser.add_argument("--dsn", default=f"sqlite:///{DEFAULT_SQLITE_PATH}", help="Database DSN")
+    parser.add_argument("--export-dir", default=str(DEFAULT_EXPORT_DIR), help="Directory for exports")
+    parser.add_argument("--host", default="127.0.0.1", help="Webhook host")
+    parser.add_argument("--port", type=int, default=8080, help="Webhook port")
+    parser.add_argument("--log-level", default=os.getenv("LOG_LEVEL", "INFO"))
+    parser.add_argument("--scheduler-hour", type=int, help="Force scheduler hour instead of current UTC hour")
+    parser.add_argument("--version", action="version", version=f"emotion-diary {__version__}")
+    return parser
+
+
+def create_storage(dsn: str) -> Storage:
+    if dsn.startswith("postgres"):
+        adapter = PostgresAdapter(dsn)
+    elif dsn.startswith("sqlite:///"):
+        adapter = SQLiteAdapter(dsn.replace("sqlite:///", "", 1) or ":memory:")
+    else:
+        adapter = SQLiteAdapter(dsn)
+    return Storage(adapter)
+
+
+def bootstrap(bus: EventBus, storage: Storage, export_dir: Path) -> None:
+    Dedup(bus)
+    Router(bus, storage)
+    CheckinWriter(bus, storage)
+    PetRender(bus)
+    Notifier(bus)
+    Export(bus, storage, export_dir=export_dir)
+    Delete(bus, storage)
+    ResponseLogger(bus)
+
+
+async def run_polling(bus: EventBus) -> None:
+    logger.info("Starting polling loop (placeholder implementation)")
+    try:
+        while True:
+            await asyncio.sleep(3600)
+    except asyncio.CancelledError:  # pragma: no cover - graceful shutdown
+        logger.info("Polling loop cancelled")
+        raise
+
+
+async def run_webhook(host: str, port: int, bus: EventBus) -> None:
+    logger.info("Starting webhook server on %s:%s (placeholder implementation)", host, port)
+    try:
+        while True:
+            await asyncio.sleep(3600)
+    except asyncio.CancelledError:  # pragma: no cover - graceful shutdown
+        logger.info("Webhook loop cancelled")
+        raise
+
+
+async def run_scheduler(bus: EventBus, storage: Storage, forced_hour: int | None = None) -> None:
+    from datetime import datetime, timezone
+
+    hour = forced_hour if forced_hour is not None else datetime.now(timezone.utc).hour
+    logger.info("Running scheduler for hour %s", hour)
+    for pid, chat_id in storage.due_users(hour):
+        await bus.publish("ping.request", {"pid": pid, "chat_id": chat_id})
+    logger.info("Scheduler finished")
+
+
+async def async_main(args: argparse.Namespace) -> None:
+    logging.basicConfig(level=getattr(logging, args.log_level.upper(), logging.INFO))
+    bus = EventBus()
+    storage = create_storage(args.dsn)
+    export_dir = Path(args.export_dir)
+    bootstrap(bus, storage, export_dir)
+
+    if args.mode == "polling":
+        await run_polling(bus)
+    elif args.mode == "webhook":
+        await run_webhook(args.host, args.port, bus)
+    elif args.mode == "scheduler":
+        await run_scheduler(bus, storage, forced_hour=args.scheduler_hour)
+    else:  # pragma: no cover - argparse ensures mode
+        raise ValueError(f"Unsupported mode {args.mode}")
+
+
+def main() -> None:
+    parser = build_parser()
+    args = parser.parse_args()
+    try:
+        asyncio.run(async_main(args))
+    except KeyboardInterrupt:  # pragma: no cover - manual interruption
+        logger.info("Interrupted by user")
+
+
+if __name__ == "__main__":
+    main()

--- a/emotion_diary/event_bus.py
+++ b/emotion_diary/event_bus.py
@@ -1,0 +1,83 @@
+"""Asynchronous in-memory event bus used by the agents."""
+
+from __future__ import annotations
+
+import asyncio
+import inspect
+import logging
+from collections import defaultdict
+from dataclasses import dataclass, field
+from typing import Any, Awaitable, Callable, Dict, Iterable, List, MutableMapping, Optional
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass(slots=True)
+class Event:
+    """Domain event with payload and metadata."""
+
+    name: str
+    payload: Dict[str, Any] = field(default_factory=dict)
+    metadata: Dict[str, Any] = field(default_factory=dict)
+
+    def copy(self, *, name: Optional[str] = None, payload: Optional[MutableMapping[str, Any]] = None,
+             metadata: Optional[MutableMapping[str, Any]] = None) -> "Event":
+        return Event(
+            name=name or self.name,
+            payload=dict(self.payload if payload is None else payload),
+            metadata=dict(self.metadata if metadata is None else metadata),
+        )
+
+
+EventHandler = Callable[[Event], Awaitable[None] | None]
+
+
+class EventBus:
+    """Simple pub/sub event bus with asyncio support."""
+
+    def __init__(self) -> None:
+        self._subscribers: Dict[str, List[EventHandler]] = defaultdict(list)
+        self._lock = asyncio.Lock()
+
+    def subscribe(self, event_name: str | Iterable[str], handler: EventHandler) -> None:
+        """Register ``handler`` for the given ``event_name`` or list of names."""
+
+        if isinstance(event_name, str):
+            event_names = [event_name]
+        else:
+            event_names = list(event_name)
+        if not event_names:
+            raise ValueError("event_name must not be empty")
+        for name in event_names:
+            logger.debug("Subscribing %s to event %s", getattr(handler, "__qualname__", repr(handler)), name)
+            self._subscribers[name].append(handler)
+
+    async def publish(
+        self, event_name: str, payload: Optional[MutableMapping[str, Any]] = None,
+        metadata: Optional[MutableMapping[str, Any]] = None,
+    ) -> None:
+        """Publish an event to all registered subscribers."""
+
+        event = Event(name=event_name, payload=dict(payload or {}), metadata=dict(metadata or {}))
+        async with self._lock:
+            subscribers = list(self._subscribers.get(event_name, ())) + list(self._subscribers.get("*", ()))
+        if not subscribers:
+            logger.debug("No subscribers for event %s", event_name)
+            return
+
+        awaitables: List[Awaitable[None]] = []
+        for handler in subscribers:
+            try:
+                result = handler(event)
+            except Exception:  # pragma: no cover - defensive logging
+                logger.exception("Unhandled exception in event handler %s", handler)
+                continue
+            if inspect.isawaitable(result):
+                awaitables.append(asyncio.ensure_future(result))
+        if awaitables:
+            await asyncio.gather(*awaitables, return_exceptions=True)
+
+    def clear(self) -> None:
+        """Remove all subscribers (useful for tests)."""
+
+        self._subscribers.clear()

--- a/emotion_diary/storage/__init__.py
+++ b/emotion_diary/storage/__init__.py
@@ -1,0 +1,17 @@
+"""Storage layer exports."""
+
+from __future__ import annotations
+
+from .adapters import DatabaseAdapter, PostgresAdapter, SQLiteAdapter
+from .core import Storage
+from .models import Entry, Ident, User
+
+__all__ = [
+    "DatabaseAdapter",
+    "SQLiteAdapter",
+    "PostgresAdapter",
+    "Storage",
+    "Entry",
+    "Ident",
+    "User",
+]

--- a/emotion_diary/storage/adapters.py
+++ b/emotion_diary/storage/adapters.py
@@ -1,0 +1,160 @@
+"""Database adapters supporting SQLite and PostgreSQL."""
+
+from __future__ import annotations
+
+import sqlite3
+from abc import ABC, abstractmethod
+from contextlib import contextmanager
+from typing import Any, Iterable, Iterator, Sequence
+
+try:  # pragma: no cover - optional dependency
+    import psycopg
+except Exception:  # pragma: no cover - fallback when psycopg is unavailable
+    psycopg = None  # type: ignore
+
+
+class DatabaseAdapter(ABC):
+    """Minimal DB-API wrapper used by the storage layer."""
+
+    placeholder: str = "?"
+
+    @abstractmethod
+    def ensure_schema(self) -> None:
+        ...
+
+    @abstractmethod
+    @contextmanager
+    def cursor(self) -> Iterator[Any]:
+        ...
+
+    def execute(self, query: str, params: Sequence[Any] | None = None) -> Any:
+        with self.cursor() as cur:
+            cur.execute(self._normalize_query(query), params or [])
+            return cur
+
+    def executemany(self, query: str, params_seq: Iterable[Sequence[Any]]) -> Any:
+        with self.cursor() as cur:
+            cur.executemany(self._normalize_query(query), params_seq)
+            return cur
+
+    def fetchone(self, query: str, params: Sequence[Any] | None = None) -> Any:
+        with self.cursor() as cur:
+            cur.execute(self._normalize_query(query), params or [])
+            return cur.fetchone()
+
+    def fetchall(self, query: str, params: Sequence[Any] | None = None) -> list[Any]:
+        with self.cursor() as cur:
+            cur.execute(self._normalize_query(query), params or [])
+            rows = cur.fetchall()
+        return list(rows)
+
+    def _normalize_query(self, query: str) -> str:
+        return query
+
+
+class SQLiteAdapter(DatabaseAdapter):
+    def __init__(self, dsn: str) -> None:
+        self._connection = sqlite3.connect(dsn, detect_types=sqlite3.PARSE_DECLTYPES)
+        self._connection.execute("PRAGMA foreign_keys=ON")
+        self._connection.row_factory = sqlite3.Row
+        self._connection.execute("PRAGMA journal_mode=WAL")
+
+    def ensure_schema(self) -> None:
+        with self.cursor() as cur:
+            cur.execute(
+                """
+                CREATE TABLE IF NOT EXISTS ident (
+                    pid TEXT PRIMARY KEY,
+                    chat_id INTEGER UNIQUE NOT NULL,
+                    created_at TIMESTAMP NOT NULL
+                )
+                """
+            )
+            cur.execute(
+                """
+                CREATE TABLE IF NOT EXISTS users (
+                    pid TEXT PRIMARY KEY REFERENCES ident(pid) ON DELETE CASCADE,
+                    tz TEXT NOT NULL,
+                    notify_hour INTEGER NOT NULL,
+                    created_at TIMESTAMP NOT NULL
+                )
+                """
+            )
+            cur.execute(
+                """
+                CREATE TABLE IF NOT EXISTS entries (
+                    id INTEGER PRIMARY KEY AUTOINCREMENT,
+                    pid TEXT NOT NULL REFERENCES ident(pid) ON DELETE CASCADE,
+                    ts TIMESTAMP NOT NULL,
+                    mood INTEGER NOT NULL,
+                    note TEXT,
+                    created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP
+                )
+                """
+            )
+            cur.execute("CREATE INDEX IF NOT EXISTS idx_entries_pid_ts ON entries(pid, ts)")
+
+    @contextmanager
+    def cursor(self) -> Iterator[sqlite3.Cursor]:
+        cur = self._connection.cursor()
+        try:
+            yield cur
+            self._connection.commit()
+        finally:
+            cur.close()
+
+
+class PostgresAdapter(DatabaseAdapter):  # pragma: no cover - requires psycopg
+    placeholder: str = "%s"
+
+    def __init__(self, dsn: str) -> None:
+        if psycopg is None:  # pragma: no cover - runtime guard
+            raise RuntimeError("psycopg is required for PostgresAdapter")
+        self._dsn = dsn
+        self._connection = psycopg.connect(dsn, autocommit=True)
+
+    def ensure_schema(self) -> None:
+        with self.cursor() as cur:
+            cur.execute(
+                """
+                CREATE TABLE IF NOT EXISTS ident (
+                    pid TEXT PRIMARY KEY,
+                    chat_id BIGINT UNIQUE NOT NULL,
+                    created_at TIMESTAMPTZ NOT NULL
+                )
+                """
+            )
+            cur.execute(
+                """
+                CREATE TABLE IF NOT EXISTS users (
+                    pid TEXT PRIMARY KEY REFERENCES ident(pid) ON DELETE CASCADE,
+                    tz TEXT NOT NULL,
+                    notify_hour INTEGER NOT NULL,
+                    created_at TIMESTAMPTZ NOT NULL
+                )
+                """
+            )
+            cur.execute(
+                """
+                CREATE TABLE IF NOT EXISTS entries (
+                    id SERIAL PRIMARY KEY,
+                    pid TEXT NOT NULL REFERENCES ident(pid) ON DELETE CASCADE,
+                    ts TIMESTAMPTZ NOT NULL,
+                    mood INTEGER NOT NULL,
+                    note TEXT,
+                    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+                )
+                """
+            )
+            cur.execute("CREATE INDEX IF NOT EXISTS idx_entries_pid_ts ON entries(pid, ts)")
+
+    @contextmanager
+    def cursor(self) -> Iterator[Any]:
+        cur = self._connection.cursor()
+        try:
+            yield cur
+        finally:
+            cur.close()
+
+    def _normalize_query(self, query: str) -> str:
+        return query.replace("?", "%s")

--- a/emotion_diary/storage/core.py
+++ b/emotion_diary/storage/core.py
@@ -1,0 +1,110 @@
+"""High level storage API that uses the database adapters."""
+
+from __future__ import annotations
+
+import hmac
+import os
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from hashlib import sha256
+from typing import List, Optional
+
+from .adapters import DatabaseAdapter
+from .models import Entry, Ident, User
+
+DEFAULT_SALT = "emotion-diary-dev"
+
+
+@dataclass(slots=True)
+class Storage:
+    adapter: DatabaseAdapter
+    ident_salt: str | None = None
+
+    def __post_init__(self) -> None:
+        self.ident_salt = self.ident_salt or os.getenv("EMOTION_DIARY_IDENT_SALT", DEFAULT_SALT)
+        self.adapter.ensure_schema()
+
+    # Ident operations -------------------------------------------------
+    def get_or_create_ident(self, chat_id: int) -> Ident:
+        row = self.adapter.fetchone("SELECT pid, chat_id, created_at FROM ident WHERE chat_id=?", (chat_id,))
+        if row:
+            created_at = row["created_at"]
+            if isinstance(created_at, str):
+                created_at = datetime.fromisoformat(created_at)
+            return Ident(pid=row["pid"], chat_id=row["chat_id"], created_at=created_at)
+        pid = self._hash_chat_id(chat_id)
+        created_at = datetime.now(timezone.utc)
+        self.adapter.execute(
+            "INSERT INTO ident (pid, chat_id, created_at) VALUES (?, ?, ?)",
+            (pid, chat_id, created_at),
+        )
+        self.ensure_user_record(pid)
+        return Ident(pid=pid, chat_id=chat_id, created_at=created_at)
+
+    def ensure_user_record(self, pid: str, tz: str = "UTC", notify_hour: int = 20) -> User:
+        row = self.adapter.fetchone("SELECT pid, tz, notify_hour, created_at FROM users WHERE pid=?", (pid,))
+        if row:
+            created_at = row["created_at"]
+            if isinstance(created_at, str):
+                created_at = datetime.fromisoformat(created_at)
+            if row["notify_hour"] != notify_hour or row["tz"] != tz:
+                self.adapter.execute(
+                    "UPDATE users SET tz=?, notify_hour=? WHERE pid=?",
+                    (tz, notify_hour, pid),
+                )
+                return User(pid=pid, tz=tz, notify_hour=notify_hour, created_at=created_at)
+            return User(pid=row["pid"], tz=row["tz"], notify_hour=row["notify_hour"], created_at=created_at)
+        created_at = datetime.now(timezone.utc)
+        self.adapter.execute(
+            "INSERT INTO users (pid, tz, notify_hour, created_at) VALUES (?, ?, ?, ?)",
+            (pid, tz, notify_hour, created_at),
+        )
+        return User(pid=pid, tz=tz, notify_hour=notify_hour, created_at=created_at)
+
+    # Entry operations -------------------------------------------------
+    def save_entry(self, pid: str, ts: datetime, mood: int, note: Optional[str]) -> Entry:
+        cur = self.adapter.execute(
+            "INSERT INTO entries (pid, ts, mood, note, created_at) VALUES (?, ?, ?, ?, ?)",
+            (pid, ts, mood, note, datetime.now(timezone.utc)),
+        )
+        entry_id = getattr(cur, "lastrowid", None)
+        return Entry(id=entry_id, pid=pid, ts=ts, mood=mood, note=note)
+
+    def list_entries(self, pid: str) -> List[Entry]:
+        rows = self.adapter.fetchall(
+            "SELECT id, pid, ts, mood, note FROM entries WHERE pid=? ORDER BY ts",
+            (pid,),
+        )
+        entries: List[Entry] = []
+        for row in rows:
+            ts = row["ts"]
+            if isinstance(ts, str):
+                ts = datetime.fromisoformat(ts)
+            entries.append(Entry(id=row["id"], pid=row["pid"], ts=ts, mood=row["mood"], note=row["note"]))
+        return entries
+
+    def delete_user(self, pid: str) -> None:
+        self.adapter.execute("DELETE FROM entries WHERE pid=?", (pid,))
+        self.adapter.execute("DELETE FROM users WHERE pid=?", (pid,))
+        self.adapter.execute("DELETE FROM ident WHERE pid=?", (pid,))
+
+    # Scheduler helpers ------------------------------------------------
+    def due_users(self, hour: int) -> List[tuple[str, int]]:
+        rows = self.adapter.fetchall(
+            """
+            SELECT users.pid as pid, ident.chat_id as chat_id
+            FROM users
+            JOIN ident ON ident.pid = users.pid
+            WHERE users.notify_hour=?
+            """,
+            (hour,),
+        )
+        return [(row["pid"], row["chat_id"]) for row in rows]
+
+    # Internal ---------------------------------------------------------
+    def _hash_chat_id(self, chat_id: int) -> str:
+        salt = self.ident_salt or DEFAULT_SALT
+        return hmac.new(salt.encode(), str(chat_id).encode(), sha256).hexdigest()
+
+
+__all__ = ["Storage", "Entry", "Ident", "User"]

--- a/emotion_diary/storage/models.py
+++ b/emotion_diary/storage/models.py
@@ -1,0 +1,51 @@
+"""Dataclasses describing storage models."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime
+from typing import Any, Dict, Optional
+
+
+@dataclass(slots=True)
+class Ident:
+    pid: str
+    chat_id: int
+    created_at: datetime
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {"pid": self.pid, "chat_id": self.chat_id, "created_at": self.created_at}
+
+
+@dataclass(slots=True)
+class User:
+    pid: str
+    tz: str
+    notify_hour: int
+    created_at: datetime
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "pid": self.pid,
+            "tz": self.tz,
+            "notify_hour": self.notify_hour,
+            "created_at": self.created_at,
+        }
+
+
+@dataclass(slots=True)
+class Entry:
+    id: Optional[int]
+    pid: str
+    ts: datetime
+    mood: int
+    note: Optional[str] = None
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "id": self.id,
+            "pid": self.pid,
+            "ts": self.ts,
+            "mood": self.mood,
+            "note": self.note,
+        }

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,8 @@
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))

--- a/tests/test_agents_flow.py
+++ b/tests/test_agents_flow.py
@@ -1,0 +1,70 @@
+from __future__ import annotations
+
+import asyncio
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+from emotion_diary.agents import CheckinWriter, Dedup, Delete, Export, Notifier, PetRender, Router
+from emotion_diary.event_bus import EventBus
+from emotion_diary.storage import SQLiteAdapter, Storage
+
+
+def test_checkin_export_delete_flow(tmp_path: Path):
+    async def _run():
+        bus = EventBus()
+        storage = Storage(SQLiteAdapter(":memory:"))
+        export_dir = tmp_path / "exports"
+
+        Dedup(bus)
+        Router(bus, storage)
+        CheckinWriter(bus, storage)
+        PetRender(bus)
+        Notifier(bus)
+        Export(bus, storage, export_dir)
+        Delete(bus, storage)
+
+        responses: list[dict] = []
+        bus.subscribe("tg.response", lambda event: responses.append(event.payload))
+
+        now = datetime.now(timezone.utc)
+        await bus.publish(
+            "tg.update",
+            {
+                "chat_id": 1001,
+                "text": "/checkin good",
+                "update_id": 1,
+                "ts": now,
+            },
+        )
+        ident = storage.get_or_create_ident(1001)
+        entries = storage.list_entries(ident.pid)
+        assert len(entries) == 1
+        assert entries[0].mood == 1
+        assert any("Записал настроение" in resp["text"] for resp in responses)
+
+        await bus.publish(
+            "tg.update",
+            {
+                "chat_id": 1001,
+                "text": "/checkin good",
+                "update_id": 1,
+                "ts": now + timedelta(minutes=1),
+            },
+        )
+        assert len(storage.list_entries(ident.pid)) == 1
+
+        storage.ensure_user_record(ident.pid, notify_hour=now.hour)
+        assert (ident.pid, 1001) in storage.due_users(now.hour)
+
+        responses.clear()
+        await bus.publish("export.request", {"pid": ident.pid, "chat_id": 1001})
+        export_files = list(export_dir.glob("*.csv"))
+        assert export_files, "export file must be created"
+        assert any("Готов экспорт данных" in resp["text"] for resp in responses)
+
+        responses.clear()
+        await bus.publish("delete.request", {"pid": ident.pid, "chat_id": 1001})
+        assert storage.list_entries(ident.pid) == []
+        assert any("данные удалены" in resp["text"].lower() for resp in responses)
+
+    asyncio.run(_run())

--- a/tests/test_event_bus.py
+++ b/tests/test_event_bus.py
@@ -1,0 +1,20 @@
+from __future__ import annotations
+
+import asyncio
+
+from emotion_diary.event_bus import EventBus
+
+
+def test_event_bus_publish_subscribe():
+    async def _run():
+        bus = EventBus()
+        received = []
+
+        async def handler(event):
+            received.append(event.payload["value"])
+
+        bus.subscribe("test.event", handler)
+        await bus.publish("test.event", {"value": 42})
+        assert received == [42]
+
+    asyncio.run(_run())


### PR DESCRIPTION
## Summary
- add the `emotion_diary` package with an async event bus and CLI entry point supporting polling, webhook, and scheduler modes
- implement the Router, Dedup, CheckinWriter, PetRender, Notifier, Export, and Delete agents that collaborate through the shared bus
- introduce the storage layer with SQLite/PostgreSQL adapters and data models plus regression tests for the event flow

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d78e5f14d483238f85bac36780c7d1