### PR TITLE
feat: send export CSV via Telegram document

### DIFF
--- a/emotion_diary/bot/transport.py
+++ b/emotion_diary/bot/transport.py
@@ -193,9 +193,21 @@ class TelegramResponder:
 
     async def handle(self, event) -> None:
         payload = dict(event.payload)
+        payload.pop("created_at", None)
         method = payload.pop("method", None)
         files = payload.pop("files", None)
+        document_path = payload.pop("document_path", None)
         if method:
+            if method == "sendDocument" and document_path and files is None:
+                doc_path = Path(document_path)
+                if doc_path.exists() and doc_path.is_file():
+                    files = {
+                        "document": (
+                            doc_path.name,
+                            doc_path.read_bytes(),
+                            "application/octet-stream",
+                        )
+                    }
             await self.api.call_method(method, payload, files=files)
             return
         chat_id = payload.pop("chat_id", None)


### PR DESCRIPTION
## Summary
- include sendDocument metadata in export-ready events and add a resilient entry loader
- update the notifier to attach CSV exports as Telegram documents and adjust responder handling
- extend transport tests to cover sendDocument calls during export

## Testing
- pytest tests/test_transport.py

------
https://chatgpt.com/codex/tasks/task_e_68d7b09699cc83238611ba0b56927609