### PR TITLE
fix: embed sprite assets as text

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,6 +135,11 @@ SLA: время от нажатия до ответа ≤1.5 с.
 | `WEBHOOK_SECRET`  | Секрет подписи входящих вебхуков для проверки подлинности. |
 | `DATABASE_URL`    | Строка подключения к базе: `sqlite:///emotion_diary.db` или `postgresql://user:pass@host/db`. |
 
+Дополнительные переменные окружения:
+
+- `EMOTION_DIARY_EXPORT_DIR` — каталог, куда будут складываться выгрузки CSV (по умолчанию `./exports`).
+- `EMOTION_DIARY_ASSETS_DIR` — путь к каталогу со спрайтами питомца. По умолчанию используется встроенная папка [`emotion_diary/assets`](emotion_diary/assets), в которую при первом запуске раскладываются PNG-файлы (они хранятся в репозитории в текстовом Base64-представлении, чтобы избежать бинарных diff).
+
 Рекомендуется хранить настройки в файле `.env` (не коммитить в репозиторий):
 
 ```dotenv
@@ -150,10 +155,10 @@ DATABASE_URL=sqlite:///emotion_diary.db
 
 ## Запуск
 
-Локальный запуск в режиме polling (получение обновлений через long polling):
+Локальный запуск в режиме polling (получение обновлений через long polling). Опционально укажите `--assets-dir`, если хотите использовать собственные изображения питомца:
 
 ```bash
-python -m emotion_diary.bot --mode polling
+python -m emotion_diary.bot --mode polling --assets-dir /path/to/custom/assets
 ```
 
 Запуск webhook-сервера (предварительно зарегистрируйте URL в Telegram через `setWebhook`):

--- a/emotion_diary/assets/__init__.py
+++ b/emotion_diary/assets/__init__.py
@@ -1,0 +1,49 @@
+"""Built-in sprite assets for the Emotion Diary bot."""
+
+from __future__ import annotations
+
+from base64 import b64decode
+from pathlib import Path
+from typing import Mapping
+
+# Base64 encoded 1x1 PNG sprites. Using inline text avoids binary blobs in the
+# repository while keeping the assets self-contained.
+_SPRITE_DATA: Mapping[str, str] = {
+    "sprite_happy_1.png": "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAIAAACQd1PeAAAADElEQVR4nGP4f9cBAAT7Ah0bgsQIAAAAAElFTkSuQmCC",
+    "sprite_happy_2.png": "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAIAAACQd1PeAAAADElEQVR4nGP4f4IBAASRAcjyuzl2AAAAAElFTkSuQmCC",
+    "sprite_neutral_1.png": "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAIAAACQd1PeAAAADElEQVR4nGNYsGABAAPEAeGUtBWxAAAAAElFTkSuQmCC",
+    "sprite_neutral_2.png": "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAIAAACQd1PeAAAADElEQVR4nGNoaGgAAAMEAYFL09IQAAAAAElFTkSuQmCC",
+    "sprite_sad_1.png": "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAIAAACQd1PeAAAADElEQVR4nGNwaPgPAALDAcBv0mA2AAAAAElFTkSuQmCC",
+    "sprite_sad_2.png": "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAIAAACQd1PeAAAADElEQVR4nGPQiNoHAAHuAUEESKSIAAAAAElFTkSuQmCC",
+}
+
+
+def ensure_builtin_assets(target_dir: Path | str | None = None) -> dict[str, Path]:
+    """Materialise bundled sprites into *target_dir*.
+
+    The project avoids shipping binary blobs in the Git repository by storing
+    sprites as base64 encoded strings. This helper decodes the images into the
+    requested directory, returning a mapping between sprite file names and the
+    resulting paths.
+    """
+
+    if target_dir is None:
+        target_dir = Path(__file__).resolve().parent
+    else:
+        target = Path(target_dir)
+        if target.is_file():
+            raise ValueError("target_dir must be a directory, not a file")
+        target_dir = target
+
+    target_dir.mkdir(parents=True, exist_ok=True)
+
+    written: dict[str, Path] = {}
+    for name, data in _SPRITE_DATA.items():
+        destination = target_dir / name
+        if not destination.exists() or destination.stat().st_size == 0:
+            destination.write_bytes(b64decode(data))
+        written[name] = destination
+    return written
+
+
+__all__ = ["ensure_builtin_assets"]

--- a/tests/test_agents_flow.py
+++ b/tests/test_agents_flow.py
@@ -60,7 +60,15 @@ def test_checkin_export_delete_flow(tmp_path: Path):
         await bus.publish("export.request", {"pid": ident.pid, "chat_id": 1001})
         export_files = list(export_dir.glob("*.csv"))
         assert export_files, "export file must be created"
-        assert any("Готов экспорт данных" in resp["text"] for resp in responses)
+        assert any(
+            (
+                "text" in resp and "Готов экспорт данных" in resp["text"]
+            )
+            or (
+                "caption" in resp and "Готов экспорт данных" in resp["caption"]
+            )
+            for resp in responses
+        )
 
         responses.clear()
         await bus.publish("delete.request", {"pid": ident.pid, "chat_id": 1001})


### PR DESCRIPTION
## Summary
- replace committed binary sprites with a text-based base64 bundle that materialises PNGs on demand
- ensure the default bot bootstrap decodes bundled sprites into the assets directory before passing it to PetRender
- document that bundled sprites are generated from base64 to avoid binary diffs

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d7b97908988323b80abd49d4e2c1d2