### PR TITLE
docs: add docstrings for agent classes

### DIFF
--- a/emotion_diary/agents/checkin_writer.py
+++ b/emotion_diary/agents/checkin_writer.py
@@ -14,13 +14,23 @@ logger = logging.getLogger(__name__)
 
 @dataclass(slots=True)
 class CheckinWriter:
+    """Persists mood entries and notifies downstream consumers."""
+
     bus: EventBus
     storage: Storage
 
     def __post_init__(self) -> None:
+        """Subscribe to check-in save events."""
+
         self.bus.subscribe("checkin.save", self.handle)
 
     async def handle(self, event: Event) -> None:
+        """Validate incoming payload and persist the mood entry.
+
+        Args:
+            event: Event carrying the check-in payload from the router.
+        """
+
         payload = event.payload
         pid = payload.get("pid")
         chat_id = payload.get("chat_id")

--- a/emotion_diary/agents/delete.py
+++ b/emotion_diary/agents/delete.py
@@ -13,13 +13,23 @@ logger = logging.getLogger(__name__)
 
 @dataclass(slots=True)
 class Delete:
+    """Handles user data removal requests."""
+
     bus: EventBus
     storage: Storage
 
     def __post_init__(self) -> None:
+        """Subscribe to delete requests on the event bus."""
+
         self.bus.subscribe("delete.request", self.handle)
 
     async def handle(self, event: Event) -> None:
+        """Remove user data and acknowledge the deletion.
+
+        Args:
+            event: Event describing which user initiated the deletion.
+        """
+
         payload = event.payload
         pid = payload.get("pid")
         chat_id = payload.get("chat_id")

--- a/emotion_diary/agents/export.py
+++ b/emotion_diary/agents/export.py
@@ -17,15 +17,25 @@ logger = logging.getLogger(__name__)
 
 @dataclass(slots=True)
 class Export:
+    """Creates CSV exports and announces their availability."""
+
     bus: EventBus
     storage: Storage
     export_dir: Path
 
     def __post_init__(self) -> None:
+        """Prepare filesystem storage and subscribe to export requests."""
+
         self.export_dir.mkdir(parents=True, exist_ok=True)
         self.bus.subscribe("export.request", self.handle)
 
     async def handle(self, event: Event) -> None:
+        """Generate CSV export for a user upon request.
+
+        Args:
+            event: Event with identifiers describing the export context.
+        """
+
         payload = event.payload
         pid = payload.get("pid")
         chat_id = payload.get("chat_id")
@@ -49,10 +59,21 @@ class Export:
         )
 
     def _load_entries(self, pid: str) -> list[Entry]:
+        """Fetch entries for export using storage APIs or fallbacks.
+
+        Args:
+            pid: Persistent identifier of the user requesting export.
+
+        Returns:
+            The list of entries sorted by timestamp for the export file.
+        """
+
         try:
             return list(self.storage.list_entries(pid))
         except Exception as exc:  # pragma: no cover - defensive fallback
-            logger.warning("Failed to load entries via storage.list_entries for %s: %s", pid, exc)
+            logger.warning(
+                "Failed to load entries via storage.list_entries for %s: %s", pid, exc
+            )
             rows = self.storage.adapter.fetchall(
                 "SELECT id, pid, CAST(ts AS TEXT) as ts, mood, note FROM entries WHERE pid=? ORDER BY ts",
                 (pid,),
@@ -76,6 +97,16 @@ class Export:
             return entries
 
     def _write_csv(self, pid: str, entries: Iterable[Entry]) -> Path:
+        """Materialise a CSV file with the provided entries.
+
+        Args:
+            pid: Persistent identifier used to name the export file.
+            entries: Iterable of storage entries to serialise.
+
+        Returns:
+            Absolute path to the generated CSV file.
+        """
+
         timestamp = datetime.now(timezone.utc).strftime("%Y%m%d%H%M%S")
         file_path = self.export_dir / f"{pid}-{timestamp}.csv"
         with file_path.open("w", newline="", encoding="utf-8") as csvfile:

--- a/emotion_diary/agents/pet_render.py
+++ b/emotion_diary/agents/pet_render.py
@@ -18,19 +18,33 @@ SPRITES = {
 
 @dataclass(slots=True)
 class PetRender:
+    """Chooses pet sprites based on mood events."""
+
     bus: EventBus
     assets_dir: Path | None = None
 
     def __post_init__(self) -> None:
+        """Subscribe to events that require sprite rendering."""
+
         self.bus.subscribe(("checkin.saved", "ping.request"), self.handle)
 
     async def handle(self, event: Event) -> None:
+        """Pick a sprite for the provided event and emit the result.
+
+        Args:
+            event: Event carrying mood information for sprite selection.
+        """
+
         payload = event.payload
         pid = payload.get("pid")
         chat_id = payload.get("chat_id")
         if pid is None or chat_id is None:
             return
-        mood = payload.get("entry", {}).get("mood") if "entry" in payload else payload.get("mood", 0)
+        mood = (
+            payload.get("entry", {}).get("mood")
+            if "entry" in payload
+            else payload.get("mood", 0)
+        )
         sprite = self._choose_sprite(int(mood or 0))
         meta = {
             "pid": pid,
@@ -41,6 +55,15 @@ class PetRender:
         await self.bus.publish("pet.rendered", meta)
 
     def _choose_sprite(self, mood: int) -> str:
+        """Select a sprite from the assets bundle based on mood.
+
+        Args:
+            mood: Mood value used to pick the sprite group.
+
+        Returns:
+            Path or filename of the selected sprite image.
+        """
+
         options = SPRITES.get(mood, SPRITES[0])
         sprite = random.choice(options)
         if self.assets_dir:


### PR DESCRIPTION
## Summary
- add Google-style docstrings to agent classes and helper methods to document their responsibilities

## Testing
- black emotion_diary/agents/router.py emotion_diary/agents/checkin_writer.py emotion_diary/agents/notifier.py emotion_diary/agents/export.py emotion_diary/agents/delete.py emotion_diary/agents/dedup.py emotion_diary/agents/pet_render.py
- ruff check emotion_diary/agents/router.py emotion_diary/agents/checkin_writer.py emotion_diary/agents/notifier.py emotion_diary/agents/export.py emotion_diary/agents/delete.py emotion_diary/agents/dedup.py emotion_diary/agents/pet_render.py

------
https://chatgpt.com/codex/tasks/task_e_68e4fe349aec8323b6c86c42f11c42fa