### PR TITLE
refactor: tighten agent typing

### DIFF
--- a/src/emotion_diary/agents/base.py
+++ b/src/emotion_diary/agents/base.py
@@ -5,13 +5,15 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import Protocol
 
-from emotion_diary.event_bus import EventBus
+from emotion_diary.event_bus import EventBus, EventHandler
 
 
 class SupportsSubscribe(Protocol):
     """Protocol describing the minimal event bus subscription interface."""
 
-    def subscribe(self, event_name: str | tuple[str, ...], handler):
+    def subscribe(
+        self, event_name: str | tuple[str, ...], handler: EventHandler
+    ) -> None:
         """Register a handler for the given event name or tuple of names."""
 
 

--- a/src/emotion_diary/agents/notifier.py
+++ b/src/emotion_diary/agents/notifier.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import logging
+from collections.abc import Mapping
 from dataclasses import dataclass
 from datetime import UTC, datetime
 from pathlib import Path
@@ -61,7 +62,7 @@ class Notifier:
         await self.bus.publish("tg.response", response)
 
     def _build_message(
-        self, event_name: str, payload: dict
+        self, event_name: str, payload: Mapping[str, Any]
     ) -> tuple[str | None, dict[str, Any]]:
         """Derive message text and extras for a Telegram response.
 


### PR DESCRIPTION
## Summary
- tighten the subscription protocol to use the concrete event handler type
- annotate notifier payload handling with mapping-aware types
- refine router command and mood resolution helpers to accept typed mappings

## Testing
- ruff check
- mypy --strict src/


------
https://chatgpt.com/codex/tasks/task_e_68e51ee0210483239071b2a3c1fd3d00