### PR TITLE
fix: normalize telegram update timestamps

### DIFF
--- a/src/emotion_diary/bot/transport.py
+++ b/src/emotion_diary/bot/transport.py
@@ -205,7 +205,7 @@ def normalize_update(update: Mapping[str, Any]) -> dict[str, Any]:
         if "message_id" in message:
             payload["message_id"] = message.get("message_id")
         ts = message.get("date")
-        if isinstance(ts, int | float):
+        if isinstance(ts, (int, float)):
             payload["ts"] = datetime.fromtimestamp(int(ts), tz=UTC)
         elif isinstance(ts, str):
             try:


### PR DESCRIPTION
## Summary
- ensure telegram updates accept numeric timestamps without raising TypeError
- assert normalization produces timezone-aware datetimes for integer dates during polling integration

## Testing
- pytest tests/test_transport.py

------
https://chatgpt.com/codex/tasks/task_e_68e5284776688323bf36a80be8842ccb