### PR TITLE
fix: format event bus imports

### DIFF
--- a/src/emotion_diary/event_bus.py
+++ b/src/emotion_diary/event_bus.py
@@ -8,9 +8,7 @@ import logging
 from collections import defaultdict
 from collections.abc import Awaitable, Callable, Iterable, MutableMapping
 from dataclasses import dataclass, field
-from typing import (
-    Any,
-)
+from typing import Any
 
 logger = logging.getLogger(__name__)
 


### PR DESCRIPTION
## Summary
- simplify the typing import in `event_bus.py` to match Black formatting expectations

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68e5fc3984888323bdd2e821bd9b6401