### PR TITLE
style: expand agent environment return type

### DIFF
--- a/tests/test_agents_flow.py
+++ b/tests/test_agents_flow.py
@@ -23,7 +23,14 @@ from emotion_diary.storage import SQLiteAdapter, Storage
 Responses = list[dict[str, Any]]
 
 
-def create_agent_environment(tmp_path: Path) -> tuple[EventBus, Storage, Path, Responses]:
+def create_agent_environment(
+    tmp_path: Path,
+) -> tuple[
+    EventBus,
+    Storage,
+    Path,
+    Responses,
+]:
     """Instantiate agents and capture outgoing responses for assertions."""
 
     bus = EventBus()


### PR DESCRIPTION
## Summary
- format the create_agent_environment return type annotation using a multi-line tuple for consistency with Black

## Testing
- black tests/test_agents_flow.py

------
https://chatgpt.com/codex/tasks/task_e_68e60450a42483238c35a284f42a0cf1