### PR TITLE
Add docstrings for test capture helpers

### DIFF
--- a/tests/test_agents_flow.py
+++ b/tests/test_agents_flow.py
@@ -48,6 +48,7 @@ def create_agent_environment(
     responses: Responses = []
 
     def capture_response(event: Event) -> None:
+        """Append emitted tg.response payloads for later assertions."""
         responses.append(event.payload)
 
     bus.subscribe("tg.response", capture_response)

--- a/tests/test_transport.py
+++ b/tests/test_transport.py
@@ -99,6 +99,7 @@ async def setup_polling_environment(tmp_path: Path) -> PollingEnvironment:
     captured_updates: list[dict[str, Any]] = []
 
     def capture_update(event: Event) -> None:
+        """Record normalised update payloads during the polling setup."""
         captured_updates.append(dict(event.payload))
 
     bus.subscribe("tg.update", capture_update)


### PR DESCRIPTION
## Summary
- add a docstring to the agents flow test helper explaining captured tg.response payloads
- document the polling setup helper's role in recording normalised updates

## Testing
- not run (docstring-only change)

------
https://chatgpt.com/codex/tasks/task_e_68e61124bfd483239e940255484efeb5